### PR TITLE
 Make VPN traffic port configurable

### DIFF
--- a/bin/gateway_init.sh
+++ b/bin/gateway_init.sh
@@ -49,8 +49,8 @@ if [ -n "${VPN_INTERFACE}" ]; then
 
     # Do not allow outbound traffic on eth0 beyond VPN and local traffic
     iptables --policy OUTPUT DROP
-    iptables -A OUTPUT -p udp --dport 443 -j ACCEPT #VPN traffic over UDP
-    iptables -A OUTPUT -p tcp --dport 443 -j ACCEPT #VPN traffic over TCP
+    iptables -A OUTPUT -p udp --dport ${VPN_TRAFFIC_PORT} -j ACCEPT #VPN traffic over UDP
+    iptables -A OUTPUT -p tcp --dport ${VPN_TRAFFIC_PORT} -j ACCEPT #VPN traffic over TCP
 
     # Allow local traffic
     for local_cidr in ${VPN_LOCAL_CIDRS}; do

--- a/config/settings.sh
+++ b/config/settings.sh
@@ -19,6 +19,8 @@ VXLAN_GATEWAY_FIRST_DYNAMIC_IP=20
 VPN_INTERFACE=tun0
 # Prevent non VPN traffic to leave the gateway
 VPN_BLOCK_OTHER_TRAFFIC=true
+# If VPN_BLOCK_OTHER_TRAFFIC is true, allow VPN traffic over this port
+VPN_TRAFFIC_PORT=443
 # Traffic to these IPs will be send through the K8S gateway
 VPN_LOCAL_CIDRS="10.0.0.0/8 192.168.0.0/16"
 


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

When `VPN_BLOCK_OTHER_TRAFFIC` is `true` currently the ports allowed for VPN traffic are hard-coded to `443`. This allows these values to be configured in `settings.sh`.

**Benefits**

This allows `VPN_BLOCK_OTHER_TRAFFIC` to be used with VPNs that don't use port `443` (ex. wireguard).

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
