### PR TITLE
Add DNSSEC Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ WORKDIR /
 # iproute2 -> bridge
 # bind-tools -> dig, bind
 # dhclient -> get dynamic IP
-# dnsmasq -> DNS & DHCP server
+# dnsmasq-dnssec -> DNS & DHCP server with DNSSEC support
 # coreutils -> need REAL chown and chmod for dhclient (it uses reference option not supported in busybox)
 # bash -> for scripting logic
 # inotify-tools -> inotifyd for dnsmask resolv.conf reload circumvention
-RUN apk add --no-cache coreutils dnsmasq iproute2 bind-tools dhclient bash inotify-tools
+RUN apk add --no-cache coreutils dnsmasq-dnssec iproute2 bind-tools dhclient bash inotify-tools
 
 COPY config /default_config
 COPY config /config

--- a/bin/gateway_sidecar.sh
+++ b/bin/gateway_sidecar.sh
@@ -33,6 +33,9 @@ log-facility=-
 # Clear DNS cache on reload
 clear-on-reload
 
+# Enable DNSSEC validation and caching
+dnssec
+
 # /etc/resolv.conf cannot be monitored by dnsmasq since it is in a different file system
 # and dnsmasq monitors directories only
 # copy_resolv.sh is used to copy the file on changes

--- a/bin/gateway_sidecar.sh
+++ b/bin/gateway_sidecar.sh
@@ -34,6 +34,7 @@ log-facility=-
 clear-on-reload
 
 # Enable DNSSEC validation and caching
+conf-file=%%PREFIX%%/share/dnsmasq/trust-anchors.conf
 dnssec
 
 # /etc/resolv.conf cannot be monitored by dnsmasq since it is in a different file system

--- a/bin/gateway_sidecar.sh
+++ b/bin/gateway_sidecar.sh
@@ -34,7 +34,7 @@ log-facility=-
 clear-on-reload
 
 # Enable DNSSEC validation and caching
-conf-file=%%PREFIX%%/share/dnsmasq/trust-anchors.conf
+conf-file=/usr/share/dnsmasq/trust-anchors.conf
 dnssec
 
 # /etc/resolv.conf cannot be monitored by dnsmasq since it is in a different file system


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Hi, I enabled DNSSEC in dnsmasq to allow DNSSEC validation.

**Benefits**

DNS requests are now validated. In my case I needed this to run mailu in my cluster. Since mailu 1.9 they require an DNS resolver that does DNSSEC validation.

**Possible drawbacks**

I'm absolutely no DNS pro and don't know much about DNSSEC. If you know any drawbacks of using DNSSEC, I'll keep my fork.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- none

**Additional information**

Thanks for the pod-gateway, I love it 😄 
