### PR TITLE
Add retry to Pod-Gateway Client

### DIFF
--- a/bin/client_init.sh
+++ b/bin/client_init.sh
@@ -45,7 +45,7 @@ ip addr
 ip route
 
 # Check we can connect to the GATEWAY IP
-ping -c1 "$GATEWAY_IP"
+ping -c "${CONNECTION_RETRY_COUNT}" "$GATEWAY_IP"
 
 # Create tunnel NIC
 ip link add vxlan0 type vxlan id "$VXLAN_ID" dev eth0 dstport 0 || true
@@ -90,6 +90,6 @@ ip addr
 ip route
 
 # Check we can connect to the gateway ussing the vxlan device
-ping -c1 "$VXLAN_GATEWAY_IP"
+ping -c "${CONNECTION_RETRY_COUNT}" "$VXLAN_GATEWAY_IP"
 
 echo "Gateway ready and reachable"

--- a/bin/client_sidecar.sh
+++ b/bin/client_sidecar.sh
@@ -16,7 +16,7 @@ while true; do
   echo "Monitor connection to $VXLAN_GATEWAY_IP"
 
   # Ping the gateway vxlan IP -> this only works when vxlan is up
-  while ping -c 1 "$VXLAN_GATEWAY_IP" > /dev/null; do
+  while ping -c "${CONNECTION_RETRY_COUNT}" "$VXLAN_GATEWAY_IP" > /dev/null; do
     # Sleep while reacting to signals
     sleep 10 &
     wait $!

--- a/config/settings.sh
+++ b/config/settings.sh
@@ -35,3 +35,7 @@ DNS_LOCAL_CIDRS="local"
 # file system so it does not work. To circumvent this a copy is made using
 # inotifyd
 RESOLV_CONF_COPY=/etc/resolv_copy.conf
+
+# ICMP heartbeats are used to ensure the pod-gateway is connectable from the clients.
+# The following value can be used to to provide more stability in an unreliable network connection.
+CONNECTION_RETRY_COUNT=1


### PR DESCRIPTION
**Description of the change**

Add `CONNECTION_RETRY_COUNT` option to control the failure threshold of gateway clients

**Benefits**

Will provide (optionally) more stability in unreliable networks

**Possible drawbacks**

Makes the code less readable. The project may not want to provide this flexibility.

**Applicable issues**

Resolves the issue/feature request listed below:
https://github.com/michaelwasher/pod-gateway/issues/36

**Additional information**
